### PR TITLE
"Add timeout functionality to processing tasks"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "main" ]
 

--- a/taske_controller_test.go
+++ b/taske_controller_test.go
@@ -67,3 +67,44 @@ func TestTasker_ProcessTasks(t *testing.T) {
 		})
 	}
 }
+
+func TestTasker_ProcessTasksWithTimeoutCtx(t *testing.T) {
+	tests := []struct {
+		name      string
+		tasks     []Task
+		want      any
+		expectErr bool
+	}{
+		{
+			name: "Test",
+			tasks: []Task{
+				MockTask{priority: 1, work: func() (any, error) { return "Task1Result", nil }},
+				MockTask{priority: 2, work: func() (any, error) { time.Sleep(time.Second * 900); return "Task2Result", nil }},
+				MockTask{priority: 3, work: func() (any, error) { return "Task3Result", fmt.Errorf("Task3Error") }},
+				MockTask{priority: 4, work: func() (any, error) { time.Sleep(time.Second); return "Task4Result", nil }},
+				MockTask{priority: 1, work: func() (any, error) { time.Sleep(time.Microsecond * 300); return "Task5Result", nil }},
+			},
+			want:      "Task1Result",
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := NewTaskController()
+			for _, task := range tt.tasks {
+				tc.AddTask(task)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond*500)
+			defer cancel()
+			got, err := tc.ProcessTasks(ctx)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("TaskController.ProcessTasks() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("TaskController.ProcessTasks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds a new test "TestTasker_ProcessTasksWithTimeoutCtx" which adds timeout control to task processing. The 'taske_controller.go' file was updated to no longer create its own context, instead it accepts a context from the caller. This allows the caller to cancel task processing via the passed context.

Task processing functionality was altered to handle the task performed in a separate goroutine so that we can select on either the context cancellation or the task result. The error field was removed from the TaskController struct as error handling is now done directly when processing tasks. Effectively, this commit allows better control over task execution.