### PR TITLE
Add context to PerformTask function for better control

### DIFF
--- a/task_controller_test.go
+++ b/task_controller_test.go
@@ -16,7 +16,7 @@ func (m MockTask) Priority() int {
 	return m.priority
 }
 
-func (m MockTask) PerformTask() (any, error) {
+func (m MockTask) PerformTask(_ context.Context) (any, error) {
 	return m.work()
 }
 


### PR DESCRIPTION
The PerformTask function in both the task_controller and task_controller_test files now accept a context. This allows for better control of task execution, including the ability to cancel or set a deadline for task executions based on the provided context.